### PR TITLE
Add egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/latex
 tags
 __pycache__
 BUILDS*
+*.egg-info


### PR DESCRIPTION
Adding a package as editable in a python environment creates a egg-info folder.

This pull request adds that folder to the gitignore